### PR TITLE
fix: add gpg provider signing

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,9 +1,13 @@
 version: 2
 before:
   hooks:
+    # this is just an example and not a requirement for provider building/publishing
     - go mod tidy
 builds:
   - env:
+      # goreleaser does not work with CGO, it could also complicate
+      # usage by users in CI/CD systems like HCP Terraform where
+      # they are unable to install libraries.
       - CGO_ENABLED=0
     mod_timestamp: '{{ .CommitTimestamp }}'
     flags:
@@ -23,7 +27,7 @@ builds:
     ignore:
       - goos: darwin
         goarch: '386'
-    binary: 'terraform-provider-{{ .ProjectName }}_{{ .Version }}'
+    binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
   - format: zip
     name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
@@ -33,9 +37,23 @@ checksum:
       name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
   name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
   algorithm: sha256
+signs:
+  - artifacts: checksum
+    args:
+      # if you are using this in a GitHub action or some other automated pipeline, you
+      # need to pass the batch flag to indicate its not interactive.
+      - "--batch"
+      - "--local-user"
+      - "{{ .Env.GPG_FINGERPRINT }}" # set this environment variable for your signing key
+      - "--output"
+      - "${signature}"
+      - "--detach-sign"
+      - "${artifact}"
 release:
   extra_files:
     - glob: 'terraform-registry-manifest.json'
       name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
+      # If you want to manually examine the release before its live, uncomment this line:
+      # draft: true
 changelog:
   disable: true


### PR DESCRIPTION
## Why

- Add GPG signing for releases to resolve the following error:

```console
│ Error: Failed to install provider
│
│ Error while installing forwardemail/forwardemail v1.2.0: could not query provider registry for registry.opentofu.org/forwardemail/forwardemail: failed to retrieve cryptographic signature for provider: 404 Not
│ Found returned from github.com
╵
```

## What

- Add GPG signing for releases

## References
- [Provider](https://search.opentofu.org/provider/forwardemail/forwardemail/latest)